### PR TITLE
fix(crypto): add proper checks to Schnorr signing algorithm

### DIFF
--- a/schnorr/schnorr.go
+++ b/schnorr/schnorr.go
@@ -4,17 +4,18 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
+
 	"github.com/FireStack-Lab/LaksaGo"
 	"github.com/FireStack-Lab/LaksaGo/keytools"
 	"github.com/btcsuite/btcd/btcec"
-	"math/big"
 )
 
-
+var bintZero = big.NewInt(0)
 
 func TrySign(privateKey []byte, publicKey []byte, message []byte, k []byte) ([]byte, []byte, error) {
-
 	priKey := new(big.Int).SetBytes(privateKey)
+	bintK := new(big.Int).SetBytes(k)
 
 	// 1a. check if private key is 0
 	if priKey.Cmp(new(big.Int).SetInt64(0)) <= 0 {
@@ -26,24 +27,32 @@ func TrySign(privateKey []byte, publicKey []byte, message []byte, k []byte) ([]b
 		return nil, nil, errors.New("private key cannot be greater than curve order")
 	}
 
+	if bintK.Cmp(bintZero) == 0 {
+		return nil, nil, errors.New("k cannot be zero")
+	}
+
+	if bintK.Cmp(keytools.Secp256k1.N) > 0 {
+		return nil, nil, errors.New("k cannot be greater than order of secp256k1")
+	}
+
 	// 2. Compute commitment Q = kG, where G is the base point
 	Qx, Qy := keytools.Secp256k1.ScalarBaseMult(k)
 
-	Q := LaksaGo.Compress(keytools.Secp256k1, Qx, Qy,true)
+	Q := LaksaGo.Compress(keytools.Secp256k1, Qx, Qy, true)
 
 	// 3. Compute the challenge r = H(Q || pubKey || msg)
 	// mod reduce r by the order of secp256k1, n
 	r := new(big.Int).SetBytes(LaksaGo.Hash(Q, publicKey, message[:]))
 	r = r.Mod(r, keytools.Secp256k1.N)
 
-	if r.Cmp(new(big.Int).SetInt64(0)) == 0 {
+	if r.Cmp(bintZero) == 0 {
 		return nil, nil, errors.New("invalid r")
 	}
 
 	//4. Compute s = k - r * prv
 	// 4a. Compute r * prv
 	_r := *r
-	s := new(big.Int).Mod(_r.Sub(new(big.Int).SetBytes(k), _r.Mul(&_r, priKey)), keytools.Secp256k1.N)
+	s := new(big.Int).Mod(_r.Sub(bintK, _r.Mul(&_r, priKey)), keytools.Secp256k1.N)
 
 	if s.Cmp(big.NewInt(0)) == 0 {
 		return nil, nil, errors.New("invalid s")
@@ -53,16 +62,24 @@ func TrySign(privateKey []byte, publicKey []byte, message []byte, k []byte) ([]b
 }
 
 func Verify(publicKey []byte, msg []byte, r []byte, s []byte) bool {
+	bintR := new(big.Int).SetBytes(r)
+	bintS := new(big.Int).SetBytes(s)
 
 	//cannot be zero
-	if new(big.Int).SetBytes(r).Cmp(new(big.Int).SetInt64(0)) == 0 || new(big.Int).SetBytes(s).Cmp(new(big.Int).SetInt64(0)) == 0 {
+	if bintR.Cmp(bintZero) == 0 || bintS.Cmp(bintZero) == 0 {
 		fmt.Printf("Invalid R or S value: cannot be zero")
 		return false
 	}
 
 	//cannot be negative
-	if new(big.Int).SetBytes(r).Sign() == -1 || new(big.Int).SetBytes(s).Sign() == -1 {
+	if bintR.Sign() == -1 || bintS.Sign() == -1 {
 		fmt.Printf("Invalid R or S value: cannot be negative")
+		return false
+	}
+
+	// cannot be greater than curve.N
+	if bintR.Cmp(keytools.Secp256k1.N) == 1 || bintS.Cmp(keytools.Secp256k1.N) == 1 {
+		fmt.Printf("Invalid R or S value: cannot be greater than order of secp256k1")
 		return false
 	}
 
@@ -77,7 +94,7 @@ func Verify(publicKey []byte, msg []byte, r []byte, s []byte) bool {
 	lx, ly := keytools.Secp256k1.ScalarMult(pkx, pky, r)
 	rx, ry := keytools.Secp256k1.ScalarBaseMult(s)
 	Qx, Qy := keytools.Secp256k1.Add(rx, ry, lx, ly)
-	Q := LaksaGo.Compress(keytools.Secp256k1, Qx, Qy,true)
+	Q := LaksaGo.Compress(keytools.Secp256k1, Qx, Qy, true)
 
 	_r := LaksaGo.Hash(Q, publicKey, msg)
 


### PR DESCRIPTION
This cleans up some of the code and adds the following crucial checks:

- 1 <= k <= curve.N
- 1 <= r,s <= curve.N

